### PR TITLE
Change the parameters of start

### DIFF
--- a/nro.c
+++ b/nro.c
@@ -24,9 +24,9 @@ static char nro_args[NRO_MAX_ARG_BUF];
 static int nro_argc;
 static char *nro_argoffs;
 
-uint64_t nro_start()
+uint64_t nro_start(uint32_t main_handle)
 {
-	uint64_t (*entry)(libtransistor_context_t*) = nro_base + 0x80;
+	uint64_t (*entry)(void*, uint32_t, libtransistor_context_t*) = nro_base + 0x80;
 	uint64_t ret;
 
 	// generate memory block
@@ -69,7 +69,7 @@ uint64_t nro_start()
 	*(void**)(get_tls() + 0x1f8) = NULL;
 
 	// run NRO
-	ret = entry(&loader_context);
+	ret = entry(NULL, main_handle, &loader_context);
 
 	// Restore TLS
 	*tls_userspace_pointer = tls_backup;
@@ -194,7 +194,7 @@ result_t nro_unload()
 	return r;
 }
 
-uint64_t nro_execute(void *load_base, int in_size)
+uint64_t nro_execute(void *load_base, int in_size, uint32_t main_handle)
 {
 	uint64_t ret;
 	result_t r;
@@ -203,7 +203,7 @@ uint64_t nro_execute(void *load_base, int in_size)
 	if(r)
 		return r;
 
-	ret = nro_start();
+	ret = nro_start(main_handle);
 
 	nro_unload(); // unload can fail; for now not a critical error
 

--- a/server.c
+++ b/server.c
@@ -95,7 +95,7 @@ int server_init()
 	return 0;
 }
 
-void server_loop()
+void server_loop(uint32_t main_handle)
 {
 	struct sockaddr_in client_addr;
 	int ret;
@@ -141,7 +141,7 @@ void server_loop()
 				if(size != heap_size && size != 0xFFFFFFFF)
 				{
 					nro_arg_name("NRO");
-					size = nro_execute(heap_base, (int)(ptr - heap_base));
+					size = nro_execute(heap_base, (int)(ptr - heap_base), main_handle);
 					printf("- NRO returned 0x%016lX\n", size);
 				}
 				continue;


### PR DESCRIPTION
On the switch, `start` takes two parameters : an exception pointer, and a handle to the main thread. For libtransistor, we'll also add a third one: a context handle. This should allow ace_loader to start apps expecting the usual switch treatment, while still providing the context to libtransistor binaries.

We get the main_thread from the main thread's context when locating the webkit threads to kill.

Should be merged together with https://github.com/reswitched/libtransistor/pull/45